### PR TITLE
Fix missing lock guard

### DIFF
--- a/src/statistics.hpp
+++ b/src/statistics.hpp
@@ -212,7 +212,7 @@ struct dumpUnspents : public TransformBase<Block> {
 			transactions.pop_front();
 		}
 
-		std::lock_guard<std::mutex>(this->mutex);
+		std::lock_guard<std::mutex> lock(this->mutex);
 		for (const auto& txo : txos) {
 			this->unspents.insort(txo.first, txo.second);
 		}


### PR DESCRIPTION
This commit fixes a bug where the lock guard (for concurrently accessing
the same scope from different threads) had basically no effect, due to
being bound to a temporary only.